### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://parsamparpary.visualstudio.com/bc37f146-a19a-4b36-b5cf-a62ccd6a94db/f8d2f382-78e9-48df-9235-3d9775f102ed/_apis/work/boardbadge/120bc9b4-86ed-4a91-ba86-38110d1faba7)](https://parsamparpary.visualstudio.com/bc37f146-a19a-4b36-b5cf-a62ccd6a94db/_boards/board/t/f8d2f382-78e9-48df-9235-3d9775f102ed/Microsoft.RequirementCategory)
 # android_device_lge_k430y
 Device repository for LG K10 K430T AOSP 6.0
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#1. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.